### PR TITLE
Show load progress when opening a playlist, and stop invalid files wiping the playlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,21 @@
         </main>
     </div>
 
+    <div id="loadingOverlay" class="loading-overlay d-none">
+        <div class="loading-box">
+            <div class="loading-phase">
+                <span id="loadingMessage" role="status" aria-live="polite">Reading file</span>
+                <span id="loadingCount" class="loading-count" aria-live="off"></span>
+            </div>
+            <div id="loadingTrack" class="loading-track" role="progressbar" aria-label="Loading playlist" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                <span class="loading-segment"><span class="loading-segment-fill"></span></span>
+                <span class="loading-segment"><span class="loading-segment-fill"></span></span>
+                <span class="loading-segment"><span class="loading-segment-fill"></span></span>
+            </div>
+            <div id="loadingDetail" class="loading-detail font-monospace"></div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js?v=v2.0-20260619"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js?v=v2.0-20260619"></script>
     <script src="script.js?v=v2.0-20260619"></script>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ const STORAGE_KEY = 'awesomeM3uEditorProject';
 const LEGACY_DATA_KEY = 'm3uData';
 const LEGACY_HEADER_KEY = 'm3uHeader';
 const NO_GROUP = 'No Group';
+const LARGE_FILE_BYTES = 100 * 1024 * 1024;
 
 
 function getStorageItem(key) {
@@ -59,6 +60,13 @@ const fileInput = document.getElementById('fileInput');
 const downloadBtn = document.getElementById('downloadBtn');
 const clearBtn = document.getElementById('clearBtn');
 const playlistHeaderInput = document.getElementById('playlistHeaderInput');
+const loadingOverlay = document.getElementById('loadingOverlay');
+const loadingMessage = document.getElementById('loadingMessage');
+const loadingCount = document.getElementById('loadingCount');
+const loadingDetail = document.getElementById('loadingDetail');
+const loadingTrack = document.getElementById('loadingTrack');
+const loadingFills = Array.from(document.querySelectorAll('.loading-segment-fill'));
+const appContainer = document.querySelector('.container-fluid');
 
 const groupsList = document.getElementById('groupsList');
 const groupsFilterInput = document.getElementById('groupsFilterInput');
@@ -1315,18 +1323,111 @@ async function checkCurrentItem() {
     await checkChannelItems([item], 'Select a channel to check.', 'current channel');
 }
 
-function handleFileUpload(event) {
+function formatFileSize(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const power = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, power);
+    return `${power === 0 || value >= 10 ? Math.round(value) : value.toFixed(1)} ${units[power]}`;
+}
+
+const LOAD_PHASES = ['Reading file', 'Finding channels', 'Building the list'];
+
+function showLoading(detail) {
+    if (!loadingOverlay) return;
+    loadingDetail.textContent = detail || '';
+    loadingOverlay.classList.remove('d-none');
+    if (appContainer) appContainer.inert = true;
+    setLoadingPhase(0, 0);
+}
+
+function setLoadingPhase(index, ratio, count) {
+    if (!loadingOverlay) return;
+
+    loadingMessage.textContent = LOAD_PHASES[index];
+    loadingCount.textContent = count || '';
+
+    loadingFills.forEach((fill, position) => {
+        const filled = position < index ? 1 : position === index ? ratio : 0;
+        fill.style.width = `${Math.round(filled * 100)}%`;
+    });
+
+    const overall = (index + ratio) / LOAD_PHASES.length;
+    loadingTrack.setAttribute('aria-valuenow', String(Math.round(overall * 100)));
+}
+
+function hideLoading() {
+    if (!loadingOverlay) return;
+    loadingOverlay.classList.add('d-none');
+    if (appContainer) appContainer.inert = false;
+    loadingFills.forEach(fill => { fill.style.width = '0%'; });
+}
+
+function nextPaint() {
+    // Background tabs never fire requestAnimationFrame, so fall back to a timer
+    // to keep the load from stalling when the user switches away mid-import.
+    return new Promise(resolve => {
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            resolve();
+        };
+        requestAnimationFrame(() => requestAnimationFrame(finish));
+        setTimeout(finish, 50);
+    });
+}
+
+function readFileAsText(file, onProgress) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error || new Error('Could not read the file.'));
+        reader.onprogress = event => {
+            if (event.lengthComputable) onProgress(event.loaded / event.total);
+        };
+        reader.readAsText(file);
+    });
+}
+
+async function handleFileUpload(event) {
     const file = event.target.files[0];
     if (!file) return;
 
-    const reader = new FileReader();
-    reader.onload = event => {
-        parseM3U(event.target.result);
+    const sizeLabel = formatFileSize(file.size);
+
+    if (file.size > LARGE_FILE_BYTES) {
+        const proceed = confirm(`This playlist is ${sizeLabel}. Loading it will take a while, and the editor will run slower afterwards.\n\nLoad it anyway?`);
+        if (!proceed) {
+            fileInput.value = '';
+            return;
+        }
+    }
+
+    showLoading(`${file.name} · ${sizeLabel}`);
+    await nextPaint();
+
+    try {
+        const content = await readFileAsText(file, ratio => {
+            setLoadingPhase(0, ratio, `${Math.round(ratio * 100)}%`);
+        });
+
+        setLoadingPhase(1, 1);
+        await nextPaint();
+        parseM3U(content);
+
+        setLoadingPhase(2, 1, `${m3uData.length.toLocaleString()} channels`);
+        await nextPaint();
         saveToLocalStorage();
         renderGroups();
         renderItems();
-    };
-    reader.readAsText(file);
+    } catch (error) {
+        console.error('Could not load the playlist file:', error);
+        alert(`Could not read ${file.name}. Check that the file still exists, then choose it again.`);
+    } finally {
+        hideLoading();
+    }
 }
 
 function parseM3U(content) {

--- a/script.js
+++ b/script.js
@@ -1415,10 +1415,18 @@ async function handleFileUpload(event) {
 
         setLoadingPhase(1, 1);
         await nextPaint();
-        parseM3U(content);
+        const parsed = parseM3U(content);
 
-        setLoadingPhase(2, 1, `${m3uData.length.toLocaleString()} channels`);
+        if (!parsed.items.length) {
+            hideLoading();
+            fileInput.value = '';
+            alert(`No channels found in ${file.name}. Your current playlist is untouched.`);
+            return;
+        }
+
+        setLoadingPhase(2, 1, `${parsed.items.length.toLocaleString()} channels`);
         await nextPaint();
+        applyParsedPlaylist(parsed);
         saveToLocalStorage();
         renderGroups();
         renderItems();
@@ -1430,18 +1438,13 @@ async function handleFileUpload(event) {
     }
 }
 
+// Parses into a standalone result and touches no editor state, so a file that
+// turns out not to be a playlist cannot destroy the one already loaded.
 function parseM3U(content) {
-    m3uData = [];
-    groupOrder = [];
-    playlistHeader = '#EXTM3U';
-    selectedGroup = null;
-    selectedGroups.clear();
-    selectedChannels.clear();
-    activeChannelId = null;
-    renamingGroup = null;
-    renamingItemId = null;
-
     const lines = String(content || '').replace(/\r/g, '').split('\n');
+    const items = [];
+    const groups = [];
+    let header = '#EXTM3U';
     let currentItem = null;
 
     lines.forEach(rawLine => {
@@ -1449,8 +1452,7 @@ function parseM3U(content) {
         if (!line) return;
 
         if (line.toUpperCase().startsWith('#EXTM3U')) {
-            playlistHeader = line;
-            playlistHeaderInput.value = playlistHeader;
+            header = line;
             return;
         }
 
@@ -1467,11 +1469,29 @@ function parseM3U(content) {
 
             currentItem.url = line;
             ensureItem(currentItem);
-            m3uData.push(currentItem);
-            ensureGroupExists(currentItem.groupTitle);
+            items.push(currentItem);
+            if (!groups.includes(currentItem.groupTitle)) groups.push(currentItem.groupTitle);
             currentItem = null;
         }
     });
+
+    return { header, items, groups };
+}
+
+function applyParsedPlaylist(parsed) {
+    m3uData = parsed.items;
+    groupOrder = parsed.groups;
+    playlistHeader = parsed.header;
+    playlistHeaderInput.value = playlistHeader;
+
+    selectedGroup = null;
+    selectedGroups.clear();
+    selectedChannels.clear();
+    activeChannelId = null;
+    renamingGroup = null;
+    renamingItemId = null;
+    groupSelectionAnchor = null;
+    itemSelectionAnchorId = null;
 
     syncGroupOrder();
     selectedGroup = groupOrder[0] || null;

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,74 @@ body {
     line-height: 1.45;
 }
 
+.loading-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1080;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(248, 249, 250, 0.85);
+}
+
+.loading-box {
+    background: #fff;
+    border: 1px solid #dee2e6;
+    padding: 1.1rem 1.25rem;
+    width: 22rem;
+    max-width: calc(100vw - 2rem);
+}
+
+.loading-phase {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    font-weight: 600;
+    color: #495057;
+}
+
+.loading-count {
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: #6c757d;
+    font-variant-numeric: tabular-nums;
+}
+
+.loading-track {
+    display: flex;
+    gap: 2px;
+    margin: 0.6rem 0 0.5rem;
+}
+
+.loading-segment {
+    flex: 1;
+    height: 6px;
+    border: 1px solid #ced4da;
+    background: #f8f9fa;
+    overflow: hidden;
+}
+
+.loading-segment-fill {
+    display: block;
+    width: 0;
+    height: 100%;
+    background: #0d6efd;
+    transition: width 0.12s linear;
+}
+
+.loading-detail {
+    font-size: 0.78rem;
+    color: #6c757d;
+    overflow-wrap: anywhere;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .loading-segment-fill {
+        transition: none;
+    }
+}
+
 #groupsList, #itemsList {
     max-height: 70vh;
     overflow-y: auto;


### PR DESCRIPTION
## Why

Choosing a file gave no feedback at all. Parsing and rendering run synchronously, so the UI simply froze until the whole playlist was drawn — on a large playlist that looks like nothing happened, and there was no way to tell a slow load from a broken one.

<img width="382" height="156" alt="image" src="https://github.com/user-attachments/assets/3d1ef4ca-b1ad-4bd6-93f2-b75f8d2cb050" />

While adding the indicator I hit a second, worse problem: `parseM3U` cleared `m3uData`, `groupOrder` and `playlistHeader` before it knew whether the input was a playlist, and it doesn't fail on unrecognised text — it just produces no channels. **Choosing the wrong file silently wiped the current playlist with no warning and no undo.**

## What changed

**Load progress.** An overlay reports the three real stages of a load — reading the file, finding channels, building the list — with a determinate bar. The reading stage fills from `FileReader`'s actual `loaded/total` bytes. The later two aren't measurable, so nothing animates a fake rate. The track is built from the same construction as the existing status badges (1px `#ced4da`, flat fill, square corners) rather than introducing a spinner, and uses the `btn-primary` blue already on the page. No new colours.

**Large-file warning.** Playlists over 100 MB prompt first, so the wait can be declined instead of just endured.

<img width="484" height="237" alt="image" src="https://github.com/user-attachments/assets/da26d3af-6a36-41af-b9aa-7f19dad8cc1b" />

**Non-destructive parsing.** `parseM3U` now parses into a standalone result and touches no editor state. A new `applyParsedPlaylist` commits it, and only runs once the parse has produced at least one channel. A file with nothing in it leaves the editor exactly as it was and says so. This also stops a failed load from overwriting the playlist header, which the old parser wrote the moment it saw an `#EXTM3U` line.

**Background-tab hang.** Staging the phases needs a yield so the browser can paint. `requestAnimationFrame` never fires in a hidden tab, so picking a file and switching away would stall the load indefinitely. `nextPaint` races rAF against a timer.

**Accessibility.** The live region is scoped to the stage label, so a screen reader isn't read every percentage tick; the track carries `role="progressbar"` with `aria-valuenow`; the app container goes `inert` during a load; the fill transition is dropped under `prefers-reduced-motion`.

## Testing

Verified in Chrome against a generated 30,000-channel / 4.8 MB playlist:

- Stages advance `Reading file` → `Finding channels` → `Building the list`, `aria-valuenow` 0 → 33 → 67 → 100, then the overlay hides and `inert` clears. 40 groups / 750 rows render.
- With `requestAnimationFrame` stubbed out entirely (the hidden-tab case), the load still completes and the app is usable again.
- A `.m3u` file containing non-playlist text, and a header-only file: playlist, groups and header all intact, with a message explaining nothing was loaded.
- Loading a second valid playlist replaces the first cleanly — new header, no stale groups, `#EXTVLCOPT` extra lines preserved.
- Over-100 MB path exercised with a synthetic 105 MB file: declining leaves the current playlist untouched.

No console errors on any path.

## Known issue, not addressed here

`saveToLocalStorage` runs on every load and will exceed the storage quota on large playlists. `setStorageItem` swallows the error, so it fails silently and the playlist is gone on reload. Out of scope for this PR, but worth a follow-up — happy to take it if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading overlay with accessible status messaging and phased progress tracking.
  * File imports now show progress details, including file size and channel counts.
  * Added cancellation support for files larger than 100 MB.
  * Added reduced-motion support for the loading experience.

* **Bug Fixes**
  * Invalid or empty imports now preserve the existing playlist.
  * Improved error handling during file imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->